### PR TITLE
API 요청 => Suspense 적용

### DIFF
--- a/src/Molecules/MainVideo/MainVideo.tsx
+++ b/src/Molecules/MainVideo/MainVideo.tsx
@@ -1,18 +1,20 @@
 import { Movie } from "@Atom/.";
 import { useMovePageHook } from "@Common/Hook/useMovePage";
-import { MainVideoType } from "@Page/VideoPage/VideoPage.hook";
+import { MovieDataType } from "@Common/Type/Data";
+import { wrapPromiseReturnType } from "@Common/Util";
 import styled from "styled-components";
 
-type Props = { movie: MainVideoType };
-export const MainVideo: React.FC<Props> = ({ movie }) => {
+type Props = { getMovieFunc: wrapPromiseReturnType<MovieDataType[]> };
+export const MainVideo: React.FC<Props> = ({ getMovieFunc }) => {
+  const movies = getMovieFunc.get() as MovieDataType[];
   const handleMovePageFn = useMovePageHook();
-  if (!movie) {
+  if (movies?.length === 0) {
     handleMovePageFn("/main");
     return null;
   }
   return (
     <MainVideoContainer>
-      <Movie {...movie} type="large" />
+      <Movie {...movies[0]} type="large" />
     </MainVideoContainer>
   );
 };

--- a/src/Molecules/MovieList/MovieList.tsx
+++ b/src/Molecules/MovieList/MovieList.tsx
@@ -1,6 +1,7 @@
 import { Movie } from "@Atom/.";
 import { useMovePageHook } from "@Common/Hook/useMovePage/.";
 import { IdType, MovieDataType } from "@Common/Type/Data";
+import { wrapPromiseReturnType } from "@Common/Util";
 import { useCallback } from "react";
 import {
   EmptyMovieListContainer,
@@ -9,26 +10,24 @@ import {
 } from "./MovieList.style";
 
 type Props = {
-  movies: MovieDataType[];
-  loading: boolean;
   titleId: IdType;
+  getMoviesFunc: wrapPromiseReturnType<MovieDataType[]>;
   type: "small" | "medium";
 };
 
 export const MovieList: React.FC<Props> = ({
   titleId,
-  movies,
-  loading,
+  getMoviesFunc,
   type,
 }) => {
+  const movies = getMoviesFunc.get();
+
   const handleMovePageFn = useMovePageHook();
   const handleGoVideoPage = useCallback(
     videoClickHelper(handleMovePageFn, titleId),
     [handleMovePageFn, titleId]
   );
-  if (!loading)
-    return <EmptyMovieListContainer> 로딩중 ...</EmptyMovieListContainer>;
-  if (movies.length === 0)
+  if (movies?.length === 0)
     return <EmptyMovieListContainer> ~ 텅 </EmptyMovieListContainer>;
 
   const ContainerComponent =
@@ -36,7 +35,7 @@ export const MovieList: React.FC<Props> = ({
 
   return (
     <ContainerComponent onClick={handleGoVideoPage}>
-      {movies.map((movie) => (
+      {movies?.map((movie: any) => (
         <Movie key={movie.movieId} {...movie} type={type} />
       ))}
     </ContainerComponent>

--- a/src/Organism/MainBody/MainBody.tsx
+++ b/src/Organism/MainBody/MainBody.tsx
@@ -1,18 +1,25 @@
 import { Flex } from "@Atom/.";
 import { MainNavBar, MovieList } from "@Molecules/.";
+import { EmptyMovieListContainer } from "@Molecules/MovieList/MovieList.style";
+import { Suspense } from "react";
 import { useGetMoviesData } from "./MainBody.hook";
 
 export const MainBody: React.FC = () => {
-  const [titleId, movies, handleTitleId, loading] = useGetMoviesData();
+  const [titleId, getMoviesFunc, handleTitleId] = useGetMoviesData();
   return (
     <Flex justify="flex-start" align="none" height="calc(100vh - 275px)">
       <MainNavBar handleTitleId={handleTitleId} titleId={titleId} />
-      <MovieList
-        titleId={titleId}
-        movies={movies}
-        loading={loading}
-        type="medium"
-      />
+      <Suspense
+        fallback={
+          <EmptyMovieListContainer> 로딩중 ...</EmptyMovieListContainer>
+        }
+      >
+        <MovieList
+          titleId={titleId}
+          getMoviesFunc={getMoviesFunc}
+          type="medium"
+        />
+      </Suspense>
     </Flex>
   );
 };

--- a/src/Page/VideoPage/VideoPage.tsx
+++ b/src/Page/VideoPage/VideoPage.tsx
@@ -1,19 +1,23 @@
 import { Flex } from "@Atom/.";
 import { MainVideo, MovieList } from "@Molecules/.";
+import { Suspense } from "react";
 import styled from "styled-components";
 import { useGetVideoData } from "./VideoPage.hook";
 
 export const VideoPage: React.FC = () => {
-  const [titleId, movies, movie] = useGetVideoData();
+  const [titleId, getMovieFunc, getMoviesFunc] = useGetVideoData();
   return (
     <VideoPageContainer>
-      <MainVideo movie={movie} />
-      <MovieList
-        titleId={titleId}
-        movies={movies}
-        loading={true}
-        type="small"
-      />
+      <Suspense fallback={<div>메인 영상</div>}>
+        <MainVideo getMovieFunc={getMovieFunc} />
+      </Suspense>
+      <Suspense fallback={<div>사이드 영상</div>}>
+        <MovieList
+          titleId={titleId}
+          getMoviesFunc={getMoviesFunc}
+          type="small"
+        />
+      </Suspense>
     </VideoPageContainer>
   );
 };

--- a/src/_Common/Util/Suspense.tsx
+++ b/src/_Common/Util/Suspense.tsx
@@ -1,11 +1,15 @@
-type wrapPromiseType<T> = (promise: Promise<T>) => any;
-export const wrapPromise: wrapPromiseType<any> = (promise) => {
+export type wrapPromiseReturnType<T> = { get: () => T | undefined };
+
+export function wrapPromise<T>(
+  promise: Promise<T>,
+  cb?: Function
+): wrapPromiseReturnType<T> {
   let status = "pending";
-  let result: any;
+  let result: T;
   let suspender = promise.then(
     (r) => {
       status = "success";
-      result = r;
+      result = cb ? cb(r) : r;
     },
     (e) => {
       status = "error";
@@ -13,7 +17,7 @@ export const wrapPromise: wrapPromiseType<any> = (promise) => {
     }
   );
   return {
-    read() {
+    get() {
       if (status === "pending") {
         throw suspender;
       } else if (status === "error") {
@@ -23,4 +27,4 @@ export const wrapPromise: wrapPromiseType<any> = (promise) => {
       }
     },
   };
-};
+}

--- a/src/_Common/Util/Suspense.tsx
+++ b/src/_Common/Util/Suspense.tsx
@@ -1,0 +1,26 @@
+type wrapPromiseType<T> = (promise: Promise<T>) => any;
+export const wrapPromise: wrapPromiseType<any> = (promise) => {
+  let status = "pending";
+  let result: any;
+  let suspender = promise.then(
+    (r) => {
+      status = "success";
+      result = r;
+    },
+    (e) => {
+      status = "error";
+      result = e;
+    }
+  );
+  return {
+    read() {
+      if (status === "pending") {
+        throw suspender;
+      } else if (status === "error") {
+        throw result;
+      } else if (status === "success") {
+        return result;
+      }
+    },
+  };
+};

--- a/src/_Common/Util/index.tsx
+++ b/src/_Common/Util/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Suspense";


### PR DESCRIPTION
React 18에 따른 Suspense 적용
이전 Suspense는 SWR, React-query, Recoil에서와 같이 Suspense 옵션이 있어야 사용가능,
API를 통해 Suspense를 적용해보았다.

뿐만아니라, 아래 영상과 같이 동시에 API 요청이 많이 발생하게 될 경우 모든 요청에 대한 data처리를 진행하고, 모든 데이터에 대하여 UI를 렌더링 진행한다는 문제점 발생

하지만, Suspense를 도입하게되면, loading 상태에서 렌더링 작업을 중지하고, 다른 작업을 진행한 후에 fetch작업이 끝나면 인터럽트를 발생시켜 UI작업을 진행하게 된다.

이 때, 여러 api 작업이 요청이 진행된다면 success를 진행하기 이전에 요청된 api들은 작업을 진행하지 않아 ui 또한 그려주지 않는다.
즉, 디바운싱과 유사하게 동작한다.

[ Suspense 미적용 ]

https://user-images.githubusercontent.com/70205497/179301499-c539762d-fe75-4129-a0ce-eb5c0120e4bc.mov

[ Suspense 적용 ]

https://user-images.githubusercontent.com/70205497/179302025-027853a8-e5ea-4966-a417-665c44ae52a0.mov


---

[ 코드 작성 이슈 ]

Pending 상태에서 promise 객체를 throw 해주고, 
Success의 경우 데이터를 return해준다.

이 때, 하위 컴포넌트에서 데이터를 get해주면 무한 로딩 발생한다.
따라서, 상위 컴포넌트에서 객체를 생성해주고 props로 전달해주어야한다.

---

[ hook 파일 무거워짐 ]

hook 내부에 사용되는 함수들이 많아져 무거워지고있는 것 같다.
util 파일을 생성하여 함수들을 관리해주려한다.